### PR TITLE
Refactor Section and SectionBuilder.

### DIFF
--- a/include/svg/figures.h
+++ b/include/svg/figures.h
@@ -158,9 +158,9 @@ class Section final {
   void Render(std::ostream &out) const;
 
  private:
-  explicit Section(std::vector<Object> objects);
+  explicit Section(std::string rendered_data);
 
-  std::shared_ptr<std::vector<Object>> objects_;
+  std::shared_ptr<std::string> rendered_data_;
 };
 
 class SectionBuilder final {

--- a/src/figures.cpp
+++ b/src/figures.cpp
@@ -3,10 +3,10 @@
 #include <cstdint>
 #include <memory>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <variant>
-#include <vector>
 
 #include "svg/common.h"
 
@@ -137,15 +137,11 @@ Rectangle &Rectangle::SetHeight(double height) {
 }
 
 void svg::Section::Render(std::ostream &out) const {
-  for (auto &figure : *objects_) {
-    std::visit([&out](auto &&figure) {
-      figure.Render(out);
-    }, figure);
-  }
+  out << *rendered_data_;
 }
 
-svg::Section::Section(std::vector<Object> objects)
-    : objects_(std::make_shared<std::vector<Object>>(std::move(objects))) {}
+svg::Section::Section(std::string rendered_data)
+    : rendered_data_(std::make_shared<std::string>(std::move(rendered_data))) {}
 
 svg::SectionBuilder &svg::SectionBuilder::Add(const svg::Object &object) {
   objects_.push_back(object);
@@ -158,5 +154,11 @@ svg::SectionBuilder &svg::SectionBuilder::Add(svg::Object &&object) {
 }
 
 svg::Section svg::SectionBuilder::Build() {
-  return Section(std::move(objects_));
+  std::ostringstream ss;
+  for (auto &object : objects_) {
+    std::visit([&ss](auto &&obj) {
+      obj.Render(ss);
+    }, object);
+  }
+  return Section(ss.str());
 }


### PR DESCRIPTION
SectionBuilder renders every figure and passes to Section ctor only the rendered string, because it can't be changed when it's already in Section.